### PR TITLE
Added search template

### DIFF
--- a/app/Resources/views/master.html.twig
+++ b/app/Resources/views/master.html.twig
@@ -5,10 +5,6 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        {% autoescape false %}
-            {{ sulu_seo(extension.seo, content, urls, shadowBaseLocale) }}
-        {% endautoescape %}
-
         {% block meta %}{% endblock %}
 
         {% block style %}{% endblock %}
@@ -29,6 +25,11 @@
                 </nav>
             {% endblock %}
         </header>
+
+        <form action="{{ path('sulu_search.website_search') }}" method="GET">
+            <input name="q" type="text" placeholder="Search" />
+            <input type="submit" value="Go" />
+        </form>
 
         <section id="content" vocab="http://schema.org/" typeof="Content">
             {% block content %}{% endblock %}

--- a/app/Resources/views/search.html.twig
+++ b/app/Resources/views/search.html.twig
@@ -1,0 +1,14 @@
+{% extends "master.html.twig" %}
+
+{% block title %}Search{% endblock %}
+
+{% block content %}
+    <h2>Showing {{ hits|length }} results for "{{ query }}"</h2>
+
+    <ul>
+    {% for i, hit in hits %}
+        <li><a href="{{ hit.document.url }}">{{ hit.document.title }}</a></li>
+    {% endfor %}
+    </ul>
+
+{% endblock %}

--- a/app/Resources/views/templates/default.html.twig
+++ b/app/Resources/views/templates/default.html.twig
@@ -1,5 +1,11 @@
 {% extends "master.html.twig" %}
 
+{% block meta %}
+    {% autoescape false %}
+        {{ sulu_seo(extension.seo, content, urls, shadowBaseLocale) }}
+    {% endautoescape %}
+{% endblock %}
+
 {% block content %}
     <h1 property="title">{{ content.title }}</h1>
 

--- a/app/Resources/views/templates/homepage.html.twig
+++ b/app/Resources/views/templates/homepage.html.twig
@@ -1,5 +1,11 @@
 {% extends "master.html.twig" %}
 
+{% block meta %}
+    {% autoescape false %}
+        {{ sulu_seo(extension.seo, content, urls, shadowBaseLocale) }}
+    {% endautoescape %}
+{% endblock %}
+
 {% block content %}
     <h1 property="title">{{ content.title }}</h1>
 

--- a/app/Resources/webspaces/example.com.xml
+++ b/app/Resources/webspaces/example.com.xml
@@ -16,6 +16,7 @@
     </default-templates>
 
     <templates>
+        <template type="search">search.html.twig</template>
         <template type="error">error/default.html.twig</template>
         <template type="error-404">error/404.html.twig</template>
     </templates>

--- a/app/config/website/routing.yml
+++ b/app/config/website/routing.yml
@@ -1,5 +1,9 @@
 sulu_media:
     resource: "@SuluMediaBundle/Resources/config/routing_website.yml"
 
+sulu_search:
+    type: portal
+    resource: "@SuluSearchBundle/Resources/config/routing_website.xml"
+
 sulu_website:
     resource: "@SuluWebsiteBundle/Resources/config/routing_website.yml"


### PR DESCRIPTION
This PR adds a `search.html.twig` template in order to support the search feature introduced in https://github.com/sulu/sulu/pull/2674.
