### PR TITLE
Remove separate environment directory from log dir

### DIFF
--- a/app/AbstractKernel.php
+++ b/app/AbstractKernel.php
@@ -124,8 +124,7 @@ abstract class AbstractKernel extends SuluKernel
         return dirname($this->rootDir) . DIRECTORY_SEPARATOR
         . 'var' . DIRECTORY_SEPARATOR
         . 'logs' . DIRECTORY_SEPARATOR
-        . $this->getContext() . DIRECTORY_SEPARATOR
-        . $this->environment;
+        . $this->getContext();
     }
 
     protected function getKernelParameters()


### PR DESCRIPTION
Reference: https://github.com/symfony/symfony-standard/blob/master/app/AppKernel.php#L43

If the purpose is easy maintainability of the cache and log dirs please ignore my PR. However, I think it's better to align with Symfony behaviour.
