### PR TITLE
Update deprecated SEO twig function usage (#49)

### DIFF
--- a/app/Resources/views/templates/default.html.twig
+++ b/app/Resources/views/templates/default.html.twig
@@ -1,9 +1,13 @@
 {% extends "master.html.twig" %}
 
 {% block meta %}
-    {% autoescape false %}
-        {{ sulu_seo(extension.seo, content, urls, shadowBaseLocale) }}
-    {% endautoescape %}
+    {% include "SuluWebsiteBundle:Extension:seo.html.twig" with {
+        "seo": extension.seo|default([]),
+        "content": content|default([]),
+        "urls": urls|default([]),
+        "shadowBaseLocale": shadowBaseLocale|default(),
+        "defaultLocale": request.defaultLocale|default('de')
+    } %}
 {% endblock %}
 
 {% block content %}

--- a/app/Resources/views/templates/homepage.html.twig
+++ b/app/Resources/views/templates/homepage.html.twig
@@ -1,9 +1,13 @@
 {% extends "master.html.twig" %}
 
 {% block meta %}
-    {% autoescape false %}
-        {{ sulu_seo(extension.seo, content, urls, shadowBaseLocale) }}
-    {% endautoescape %}
+    {% include "SuluWebsiteBundle:Extension:seo.html.twig" with {
+        "seo": extension.seo|default([]),
+        "content": content|default([]),
+        "urls": urls|default([]),
+        "shadowBaseLocale": shadowBaseLocale|default(),
+        "defaultLocale": request.defaultLocale|default('de')
+    } %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This PR addresses #49 
It's not really a fix but since a lot of people use this repo to start a project, it stops them from using something that's deprecated and getting stuck further down the line when adding articles etc. and will make sure that the twig function can actually be removed at some point.

Unfortunately, twig functions aren't clearly marked as deprecated - it was only while trying to find a solution that I saw that there was a new way of doing this.