### PR TITLE
Update APC classes in prod config

### DIFF
--- a/app/config/website/config_prod.yml
+++ b/app/config/website/config_prod.yml
@@ -5,7 +5,7 @@ imports:
 #    validation:
 #        cache: validator.mapping.cache.doctrine.apcu
 #    serializer:
-#        cache: serializer.mapping.cache.apcu
+#        cache: doctrine.cache.apcu
 
 #doctrine:
 #    orm:

--- a/app/config/website/config_prod.yml
+++ b/app/config/website/config_prod.yml
@@ -3,15 +3,15 @@ imports:
 
 #framework:
 #    validation:
-#        cache: validator.mapping.cache.doctrine.apc
+#        cache: validator.mapping.cache.doctrine.apcu
 #    serializer:
-#        cache: serializer.mapping.cache.apc
+#        cache: serializer.mapping.cache.apcu
 
 #doctrine:
 #    orm:
-#        metadata_cache_driver: apc
-#        result_cache_driver: apc
-#        query_cache_driver: apc
+#        metadata_cache_driver: apcu
+#        result_cache_driver: apcu
+#        query_cache_driver: apcu
 
 monolog:
     handlers:


### PR DESCRIPTION
Since PHP 7.1 and DoctrineCache 1.6.4 this breaks:
`Attempted to call function "apc_fetch" from namespace "Doctrine\Common\Cache".`