### PR TITLE
Add test environment

### DIFF
--- a/app/Resources/webspaces/example.com.xml
+++ b/app/Resources/webspaces/example.com.xml
@@ -48,6 +48,11 @@
                         <url language="en">{host}</url>
                     </urls>
                 </environment>
+                <environment type="test">
+                    <urls>
+                        <url language="en">{host}</url>
+                    </urls>
+                </environment>
                 <environment type="dev">
                     <urls>
                         <url language="en">{host}</url>

--- a/app/config/admin/config.yml
+++ b/app/config/admin/config.yml
@@ -1,5 +1,4 @@
 imports:
-    - { resource: security.yml }
     - { resource: ../config.yml }
 
 # SuluAdmin Configuration

--- a/app/config/admin/config_dev.yml
+++ b/app/config/admin/config_dev.yml
@@ -1,4 +1,5 @@
 imports:
+    - { resource: security.yml }
     - { resource: config.yml }
 
 framework:

--- a/app/config/admin/config_prod.yml
+++ b/app/config/admin/config_prod.yml
@@ -1,4 +1,5 @@
 imports:
+    - { resource: security.yml }
     - { resource: config.yml }
 
 #framework:

--- a/app/config/admin/config_stage.yml
+++ b/app/config/admin/config_stage.yml
@@ -1,4 +1,5 @@
 imports:
+    - { resource: security.yml }
     - { resource: config.yml }
 
 monolog:

--- a/app/config/admin/config_test.yml
+++ b/app/config/admin/config_test.yml
@@ -1,0 +1,56 @@
+imports:
+    - { resource: config.yml }
+
+framework:
+    router:
+        resource: "%kernel.root_dir%/config/admin/routing_dev.yml"
+        strict_requirements: true
+    test: ~
+    session:
+        storage_id: session.storage.mock_file
+    profiler:
+        enabled: false
+
+web_profiler:
+    toolbar: false
+    intercept_redirects: false
+
+swiftmailer:
+    disable_delivery: true
+    transport: "null"
+
+doctrine:
+    dbal:
+        host: 127.0.0.1
+        dbname: %database_name%_test
+        user: root
+        password:
+
+monolog:
+    handlers:
+        console:
+            type: console
+            bubble: false
+
+security:
+    access_decision_manager:
+        strategy: affirmative
+
+    encoders:
+        legacy_encoder: plaintext
+        Sulu\Bundle\SecurityBundle\Entity\User: plaintext
+
+    providers:
+        testprovider:
+            id: test_user_provider
+
+    firewalls:
+        test:
+            http_basic:
+
+sulu_security:
+    checker:
+        enabled: true
+
+sulu_test:
+    enable_test_user_provider: true

--- a/app/config/website/config.yml
+++ b/app/config/website/config.yml
@@ -1,5 +1,4 @@
 imports:
-    - { resource: security.yml }
     - { resource: ../config.yml }
 
 # SymfonyCMF Configuration

--- a/app/config/website/config_dev.yml
+++ b/app/config/website/config_dev.yml
@@ -1,4 +1,5 @@
 imports:
+    - { resource: security.yml }
     - { resource: config.yml }
 
 framework:

--- a/app/config/website/config_prod.yml
+++ b/app/config/website/config_prod.yml
@@ -1,4 +1,5 @@
 imports:
+    - { resource: security.yml }
     - { resource: config.yml }
 
 #framework:

--- a/app/config/website/config_stage.yml
+++ b/app/config/website/config_stage.yml
@@ -1,4 +1,5 @@
 imports:
+    - { resource: security.yml }
     - { resource: config.yml }
 
 monolog:

--- a/app/config/website/config_test.yml
+++ b/app/config/website/config_test.yml
@@ -1,0 +1,36 @@
+imports:
+    - { resource: config.yml }
+
+framework:
+    router:
+        resource: "%kernel.root_dir%/config/website/routing_dev.yml"
+        strict_requirements: true
+    test: ~
+    session:
+        storage_id: session.storage.mock_file
+    profiler:
+        enabled: false
+
+web_profiler:
+    toolbar: false
+    intercept_redirects: false
+
+swiftmailer:
+    disable_delivery: true
+    transport: "null"
+
+doctrine:
+    dbal:
+        host: 127.0.0.1
+        dbname: %database_name%_test
+        user: root
+        password:
+
+monolog:
+    handlers:
+        console:
+            type:   console
+            bubble: false
+
+sulu_test:
+    enable_test_user_provider: true

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,10 @@
             "app/WebsiteKernel.php"
         ]
     },
+    "autoload-dev": {
+        "psr-4": { "Tests\\": "tests/" },
+        "files": [ "vendor/symfony/symfony/src/Symfony/Component/VarDumper/Resources/functions/dump.php" ]
+    },
     "require": {
         "php": "^5.5.9 || ~7.0",
         "twig/extensions": "^1.0",
@@ -36,7 +40,8 @@
     },
     "require-dev": {
         "sensio/generator-bundle": "~2.8 || ~3.0",
-        "phpcr/phpcr-shell": "~1.0"
+        "phpcr/phpcr-shell": "~1.0",
+        "symfony/phpunit-bridge": "^3.3"
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,7 @@
         ]
     },
     "autoload-dev": {
-        "psr-4": { "Tests\\": "tests/" },
-        "files": [ "vendor/symfony/symfony/src/Symfony/Component/VarDumper/Resources/functions/dump.php" ]
+        "psr-4": { "Tests\\": "tests/" }
     },
     "require": {
         "php": "^5.5.9 || ~7.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,8 +28,5 @@
             </exclude>
         </whitelist>
     </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
-    </listeners>
 </phpunit>
+

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.7/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+>
+    <php>
+        <server name="KERNEL_DIR" value="app"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+    </php>
+
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+            <exclude>
+                <directory>src/*Bundle/Resources</directory>
+                <directory>src/*/*Bundle/Resources</directory>
+                <directory>src/*/Bundle/*Bundle/Resources</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener" />
+    </listeners>
+</phpunit>


### PR DESCRIPTION
Add test environment to avoid common pitfalls in incorrect configuration for security setup.

You can use the following `patch` file to have some basic tests:

https://gist.githubusercontent.com/alexander-schranz/8a0dda598537ad5740faefe6333637e8/raw/91a7ca6fc534fd6cacab2eead8a549e1f3a2b07d/test-case.patch

**To be discussed**:

 - Should we also add a abstract `AdminTestCase` and `WebsiteTestCase` so its easier to create functional tests foreach Kernel (See [patch](https://gist.githubusercontent.com/alexander-schranz/8a0dda598537ad5740faefe6333637e8/raw/91a7ca6fc534fd6cacab2eead8a549e1f3a2b07d/test-case.patch) file for example). 