### PR TITLE
Make maintenance mode available by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 # app
 /app/bootstrap.php.cache
 /app/config/parameters.yml
-app/maintenance.php
 
 # bin
 /bin/*

--- a/app/maintenance.php
+++ b/app/maintenance.php
@@ -3,23 +3,23 @@
 define('DEFAULT_LOCALE', 'en');
 
 // allow acces for following ips
-$allowedIPs = array(
+$allowedIPs = [
   '127.0.0.1',
-);
+];
 
 // translations for maintenance
-$translations = array(
-    'en' => array(
+$translations = [
+    'en' => [
         'title' => 'Maintenance',
         'heading' => 'The page is currently down for maintenance',
         'description' => 'Sorry for any inconvenience caused. Please try again shortly.',
-    ),
-    'de' => array(
+    ],
+    'de' => [
         'title' => 'Wartungsarbeiten',
         'heading' => 'Die Seite wird derzeit gewartet',
         'description' => 'Wir bitten um Verständnis. Bitte versuche es in Kürze erneut.',
-    ),
-);
+    ],
+];
 
 // check if ip is within allowed range
 if (in_array($_SERVER['REMOTE_ADDR'], $allowedIPs)) {

--- a/web/website.php
+++ b/web/website.php
@@ -19,8 +19,8 @@ defined('SYMFONY_DEBUG') ||
     define('SYMFONY_DEBUG', filter_var(getenv('SYMFONY_DEBUG') ?: SYMFONY_ENV === 'dev', FILTER_VALIDATE_BOOLEAN));
 
 // maintenance mode
-$maintenanceFilePath = __DIR__ . '/../app/maintenance.php';
-if (SULU_MAINTENANCE && file_exists($maintenanceFilePath)) {
+if (SULU_MAINTENANCE) {
+    $maintenanceFilePath = __DIR__ . '/../app/maintenance.php';
     // show maintenance mode and exit if no allowed IP is met
     if (require $maintenanceFilePath) {
         exit();


### PR DESCRIPTION
It seems like when sulu-minimal was created with removing all `.dist` files it was forgot to also do this for the maintenance mode file.

Its also better for project as mostly when you need you see that the maintenance file not exists and can't be created easily on some cloud systems.

The maintenance mode is only activated by ENVIRONMENT variable: https://github.com/sulu/sulu-minimal/blob/1.6.12/web/website.php#L17