### PR TITLE
RFC: Set charset to utf8mb4

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -43,8 +43,11 @@ doctrine:
         dbname:   "%database_name%"
         user:     "%database_user%"
         password: "%database_password%"
-        charset:  UTF8
         server_version: "%database_version%"
+        charset: utf8mb4
+        default_table_options:
+            charset: utf8mb4
+            collate: utf8mb4_unicode_ci
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"
         naming_strategy: doctrine.orm.naming_strategy.underscore


### PR DESCRIPTION
I'm not sure if this is good as other databases like postgresql don't know utf8mb4 and will fail. So maybe we should just add it to the documentation like symfony. See https://symfony.com/doc/3.4/doctrine.html