### PR TITLE
Added explicit symfony dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,12 @@
     "require": {
         "php": "^7.1",
         "twig/extensions": "^1.0",
-        "symfony/symfony": "^3.3",
-        "symfony/monolog-bundle": "^2.8.7 || ^3.0",
+        "symfony/config": "^3.3",
+        "symfony/framework-bundle": "^3.3",
+        "symfony/monolog-bridge": "^3.3",
+        "symfony/monolog-bundle": "^3.0",
+        "symfony/swiftmailer-bundle": "^3.0",
+        "symfony/twig-bundle": "^3.3",
         "sensio/distribution-bundle": "^5.0",
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "^2.0",
@@ -40,7 +44,13 @@
     "require-dev": {
         "sensio/generator-bundle": "~2.8 || ~3.0",
         "phpcr/phpcr-shell": "~1.0",
-        "symfony/phpunit-bridge": "^3.3"
+        "symfony/debug": "^3.3",
+        "symfony/debug-bundle": "^3.3",
+        "symfony/inflector": "^3.3",
+        "symfony/phpunit-bridge": "^3.3",
+        "symfony/var-dumper": "^3.3",
+        "symfony/web-profiler-bundle": "^3.3",
+        "symfony/web-server-bundle": "^3.3"
     },
     "scripts": {
         "post-install-cmd": [


### PR DESCRIPTION
This PR changes the dependency to `symfony/symfony` to explicit bundles and components.

Related: https://github.com/sulu/sulu/pull/3781
Requires: https://github.com/sulu/sulu/pull/3788
