### PR TITLE
Fix compatibility with php 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ cache:
 
 matrix:
   include:
-    - php: 5.6
+    - php: 5.5
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"
-    - php: 7.0
+    - php: 7.1
       env:
         - COMPOSER_FLAGS="--prefer-dist --no-interaction"
 

--- a/app/AbstractKernel.php
+++ b/app/AbstractKernel.php
@@ -79,7 +79,9 @@ abstract class AbstractKernel extends SuluKernel
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
-            $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
+            if (class_exists('Symfony\Bundle\WebServerBundle\WebServerBundle')) {
+                $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
+            }
 
             // debug enhancement
             $bundles[] = new Sulu\Bundle\TestBundle\SuluTestBundle();

--- a/composer.json
+++ b/composer.json
@@ -20,27 +20,26 @@
     "require": {
         "php": "^5.5.9 || ~7.0",
         "twig/extensions": "^1.0",
-        "symfony/symfony": "^3.3",
+        "symfony/symfony": "^2.8.7 || ^3.0",
         "symfony/monolog-bundle": "^2.8.7 || ^3.0",
-        "sensio/distribution-bundle": "^5.0",
+        "sensio/distribution-bundle": "^5.0.6",
         "sensio/framework-extra-bundle": "^3.0.2",
-        "incenteev/composer-parameter-handler": "^2.0",
+        "incenteev/composer-parameter-handler": "~2.1",
         "sulu/sulu": "~1.6.0",
         "dantleech/phpcr-migrations-bundle": "~1.0",
         "zendframework/zend-stdlib": "^2.3",
         "zendframework/zendsearch": "@dev",
         "massive/build-bundle": "0.3.*",
         "jackalope/jackalope-doctrine-dbal": "^1.2.5",
-        "jackalope/jackalope-jackrabbit": "^1.2.0",
+        "jackalope/jackalope-jackrabbit": "^1.2",
         "doctrine/doctrine-fixtures-bundle": "~2.3",
         "doctrine/doctrine-bundle": "^1.0",
-        "doctrine/doctrine-cache-bundle": "^1.0",
-        "oro/doctrine-extensions": "^1.0"
+        "doctrine/doctrine-cache-bundle": "^1.0"
     },
     "require-dev": {
         "sensio/generator-bundle": "~2.8 || ~3.0",
         "phpcr/phpcr-shell": "~1.0",
-        "symfony/phpunit-bridge": "^3.3"
+        "symfony/phpunit-bridge": "^2.8.7 || ^3.0"
     },
     "scripts": {
         "post-install-cmd": [

--- a/tests/travis.php.ini
+++ b/tests/travis.php.ini
@@ -1,1 +1,1 @@
-memory_limit = 2048M
+memory_limit = 4096M


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Allow symfony 3.3 and check if web server bundle exists.

#### Why?

Fix the compatibility with php 5.5 

#### Example Usage

~~~php
php55 /usr/local/bin/composer install
~~~

