### PR TITLE
Set better defaults for example templates

### DIFF
--- a/app/Resources/templates/pages/default.xml
+++ b/app/Resources/templates/pages/default.xml
@@ -7,7 +7,7 @@
 
     <view>templates/default</view>
     <controller>SuluWebsiteBundle:Default:index</controller>
-    <cacheLifetime>1209600</cacheLifetime>
+    <cacheLifetime>604800</cacheLifetime>
 
     <meta>
         <title lang="en">Default</title>

--- a/app/Resources/templates/pages/default.xml
+++ b/app/Resources/templates/pages/default.xml
@@ -7,7 +7,7 @@
 
     <view>templates/default</view>
     <controller>SuluWebsiteBundle:Default:index</controller>
-    <cacheLifetime>2400</cacheLifetime>
+    <cacheLifetime>1209600</cacheLifetime>
 
     <meta>
         <title lang="en">Default</title>

--- a/app/Resources/templates/pages/homepage.xml
+++ b/app/Resources/templates/pages/homepage.xml
@@ -7,7 +7,7 @@
 
     <view>templates/homepage</view>
     <controller>SuluWebsiteBundle:Default:index</controller>
-    <cacheLifetime>2400</cacheLifetime>
+    <cacheLifetime>86400</cacheLifetime>
 
     <meta>
         <title lang="en">Homepage</title>


### PR DESCRIPTION
The current cacheLifeTime set in the xmls are not recommended values to be used in real world environment.