### PR TITLE
Fixes that test environment write into same index as live

### DIFF
--- a/app/config/admin/config_test.yml
+++ b/app/config/admin/config_test.yml
@@ -51,3 +51,7 @@ sulu_security:
 
 sulu_test:
     enable_test_user_provider: true
+
+massive_search:
+    metadata:
+        prefix: test

--- a/app/config/website/config_test.yml
+++ b/app/config/website/config_test.yml
@@ -31,3 +31,7 @@ monolog:
 
 sulu_test:
     enable_test_user_provider: true
+
+massive_search:
+    metadata:
+        prefix: test


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Realted PRs? | https://github.com/sulu/sulu-standard/pull/849
| License | MIT

#### What's in this PR?

Set the massive_search_prefix to `test` in test environment.

#### Why?

Currently the test write into the same index as the other environment which should be avoided.

#### Example Usage

~~~php
SYMFONY_ENV=test bin/simple-phpunit
~~~

