### PR TITLE
Add fos rest zone configuration for sulu exception listener

### DIFF
--- a/config/packages/fos_rest.yaml
+++ b/config/packages/fos_rest.yaml
@@ -1,0 +1,4 @@
+fos_rest:
+    zone:
+        - { path: ^/admin/* }
+        - { path: ^/api/* }

--- a/config/packages/fos_rest.yaml
+++ b/config/packages/fos_rest.yaml
@@ -1,4 +1,3 @@
 fos_rest:
     zone:
         - { path: ^/admin/* }
-        - { path: ^/api/* }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related PRs | https://github.com/sulu/sulu/pull/4152
| License | MIT

#### What's in this PR?

Add fos rest zone configuration for sulu exception listener

#### Why?

Sulu can't prepend this configuration:

>   Configuration path "fos_rest.zone" cannot be overwritten. You have to define all options for this path, and any of its sub-paths
  in one configuration section.

#### Example Usage

Instead configure this in your project configuration:

~~~php
fos_rest:
    zone:
        - { path: ^/admin/* }
        - { path: ^/api/* }
~~~

