### PR TITLE
Allow symfony 3.4 compatible versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "symfony/swiftmailer-bundle": "^2.6.4 || ^3.0",
         "symfony/twig-bundle": "^3.4",
         "sensio/framework-extra-bundle": "^5.0",
-        "incenteev/composer-parameter-handler": "^2.0",
         "sulu/sulu": "2.0.0-alpha4",
         "dantleech/phpcr-migrations-bundle": "^1.1",
         "zendframework/zend-stdlib": "^2.3",
@@ -27,7 +26,7 @@
         "oro/doctrine-extensions": "^1.0"
     },
     "require-dev": {
-        "phpcr/phpcr-shell": "~1.1.1",
+        "phpcr/phpcr-shell": "~1.0",
         "symfony/debug": "^3.4 || ^4.0",
         "symfony/debug-bundle": "^3.4 || ^4.0",
         "symfony/dotenv": "^3.4 || ^4.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/sulu/sulu/pull/4169
| License | MIT

#### What's in this PR?

Allow symfony 3.4 compatible versions and remove unnecessary requirements.

#### Why?

We should support as many versions of a library as possible to make the update to sulu 2.0 easier.

