### PR TITLE
Remove deprecated sulu.rlp tag

### DIFF
--- a/config/templates/pages/default.xml
+++ b/config/templates/pages/default.xml
@@ -34,8 +34,6 @@
                         <title lang="en">Resourcelocator</title>
                         <title lang="de">Adresse</title>
                     </meta>
-
-                    <tag name="sulu.rlp"/>
                 </property>
             </properties>
         </section>

--- a/config/templates/pages/homepage.xml
+++ b/config/templates/pages/homepage.xml
@@ -34,8 +34,6 @@
                         <title lang="en">Resourcelocator</title>
                         <title lang="de">Adresse</title>
                     </meta>
-
-                    <tag name="sulu.rlp"/>
                 </property>
             </properties>
         </section>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related PRs | sulu/sulu#4069
| License | MIT

#### What's in this PR?

Remove deprecated sulu.rlp tag.

#### Why?

The sulu.rlp tag is not longer needed the result of the rlp string is simple set to the resource_locator content type.

#### To Do

- [x] Add breaking changes to UPGRADE.md (exists)
