### PR TITLE
Remove unneeded sensio extra framework bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,6 @@
         "symfony/monolog-bundle": "^3.1",
         "symfony/swiftmailer-bundle": "^2.6.4 || ^3.0",
         "symfony/twig-bundle": "^3.4",
-        "sensio/framework-extra-bundle": "^5.0",
         "sulu/sulu": "2.0.0-alpha4",
         "dantleech/phpcr-migrations-bundle": "^1.1",
         "zendframework/zend-stdlib": "^2.3",

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -5,7 +5,6 @@ return [
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
     Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle::class => ['all' => true],
-    Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle::class => ['all' => true],
     Sulu\Bundle\CoreBundle\SuluCoreBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineCacheBundle\DoctrineCacheBundle::class => ['all' => true],


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | sulu/sulu#4215
| License | MIT
#### What's in this PR?

Remove unneeded sensio extra framework bundle.

#### Why?

Most features where moved to the symfony core like route annotations and sensio extra framework bundle is not shipped with symfony flex boilerplate.