### PR TITLE
Implement test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         - APP_SECRET=a448d1dfcaa563fce56c2fd9981f662b
         - MAILER_URL=null://localhost
         - SULU_ADMIN_EMAIL=
-        - DATABASE_URL=mysql://root:@127.0.0.1/sulu_test
+        - DATABASE_TEST_URL=mysql://root:@127.0.0.1/sulu_test
         - COMPOSER_FLAGS="--no-interaction"
 
     # Without ENVIRONMENT variables

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
   MAILER_URL: null://localhost
   SULU_ADMIN_EMAIL: example@localhost
   PHPCR_TRANSPORT: doctrinedbal
-  DATABASE_URL: mysql://root:Password12!@127.0.0.1/sulu_test
+  DATABASE_TEST_URL: mysql://root:Password12!@127.0.0.1/sulu_test
   DATABASE_CHARSET: utf8mb4
   DATABASE_COLLATE: utf8mb4_unicode_ci
   matrix:

--- a/config/packages/test/doctrine.yaml
+++ b/config/packages/test/doctrine.yaml
@@ -1,0 +1,6 @@
+parameters:
+    env(DATABASE_TEST_URL): '%env(resolve:DATABASE_URL)%_test'
+
+doctrine:
+    dbal:
+        url: '%env(resolve:DATABASE_TEST_URL)%'

--- a/config/packages/test/massive_search.yaml
+++ b/config/packages/test/massive_search.yaml
@@ -1,0 +1,3 @@
+massive_search:
+    metadata:
+        prefix: test

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,28 +5,21 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/5.7/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
 >
     <php>
-        <server name="KERNEL_DIR" value="app"/>
+        <ini name="error_reporting" value="-1" />
+        <env name="KERNEL_CLASS" value="App\Kernel" />
+        <env name="APP_ENV" value="test" />
+        <env name="APP_DEBUG" value="1" />
+        <env name="APP_SECRET" value=""/>
+        <env name="DATABASE_TEST_URL" value="mysql://db_user:db_password@127.0.0.1:3306/db_name_test"/>
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
     <testsuites>
         <testsuite name="Project Test Suite">
-            <directory>tests</directory>
+            <directory>tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-            <exclude>
-                <directory>src/*Bundle/Resources</directory>
-                <directory>src/*/*Bundle/Resources</directory>
-                <directory>src/*/Bundle/*Bundle/Resources</directory>
-            </exclude>
-        </whitelist>
-    </filter>
 </phpunit>
-

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,27 @@
+<?php
+
+require __DIR__ . '/../vendor/autoload.php';
+
+// Create test database
+$cmd = sprintf(
+    'php "%s/../bin/adminconsole" doctrine:database:create --if-not-exists',
+    __DIR__
+);
+
+passthru($cmd, $exitCode);
+
+if ($exitCode) {
+    exit($exitCode);
+}
+
+// Create or update test database schema
+$cmd = sprintf(
+    'php "%s/../bin/adminconsole" doctrine:schema:update --force',
+    __DIR__
+);
+
+passthru($cmd, $exitCode);
+
+if ($exitCode) {
+    exit($exitCode);
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related PRs | #109, #67
| License | MIT

#### What's in this PR?

Avoids conflicts between dev and test environments. 

#### Why?

Normally symfony application uses [sqlite](https://github.com/symfony/demo/blob/e5c8d21fd26684e85de3b9e8ed2c7f8f8f68ed1b/phpunit.xml.dist#L17) in the tests as this is not possible with sulu I set it to mysql. To avoid that tests are run accidently on a live database I introduced a extra env variable which will fallback to DATABASE_URl with postfix _test.

Also it provides a bootstrap script which will create the test database and update its schema.

#### Example Usage

```php
bin/phpunit
```

