### PR TITLE
Add test setup with custom test database

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,8 @@ matrix:
       install:
         - composer create-project sulu/sulu-minimal ../test-create-project-dir --repository="{\"type\":\"path\",\"url\":\"./\"}" --stability=dev -n
         - cd ../test-create-project-dir
-        - echo 'DATABASE_URL=mysql://root:@127.0.0.1:3306/sulu_test' >> .env.local
+        - echo 'DATABASE_URL=mysql://root:@127.0.0.1:3306/sulu' >> .env.local
+        - echo 'DATABASE_URL=mysql://root:@127.0.0.1:3306/sulu_test' >> .env.test.local
       env:
         - NPM_BUILD=true
         - COMPOSER_VALIDATE_FLAGS="--strict --no-check-publish"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,11 +5,11 @@
          xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="config/bootstrap.php"
+         bootstrap="tests/bootstrap.php"
 >
     <php>
         <ini name="error_reporting" value="-1" />
-        <env name="APP_ENV" value="test" />
+        <env name="APP_ENV" value="test" force="true"/>
         <env name="SHELL_VERBOSITY" value="-1" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
@@ -26,4 +26,3 @@
         </whitelist>
     </filter>
 </phpunit>
-

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../config/bootstrap.php';
+
+$databaseCreatedFile = __DIR__ . '/../var/cache/admin/test/adminApp_KernelTestDebugContainer.php';
+
+// For dev performance create database only in case of not exist cache directory
+if (!file_exists($databaseCreatedFile)) {
+    // Create test database
+    $cmd = sprintf(
+        'php "%s/../bin/adminconsole" doctrine:database:create --if-not-exists',
+        __DIR__
+    );
+
+    passthru($cmd, $exitCode);
+
+    if ($exitCode) {
+        exit($exitCode);
+    }
+
+    // Create or update test database schema
+    $cmd = sprintf(
+        'php "%s/../bin/adminconsole" doctrine:schema:update --dump-sql --force --complete',
+        __DIR__
+    );
+
+    passthru($cmd, $exitCode);
+
+    if ($exitCode) {
+        exit($exitCode);
+    }
+}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related PRs | #109, #67
| License | MIT

#### What's in this PR?

Avoids conflicts between dev and test environments. 

#### Why?

Normally [symfony application](https://github.com/symfony/symfony-demo) uses [sqlite](https://github.com/symfony/demo/blob/e5c8d21fd26684e85de3b9e8ed2c7f8f8f68ed1b/phpunit.xml.dist#L17) in the tests as this is not possible with sulu I set it the database_url with a _test postfix

Also it provides a bootstrap script which will create the test database and update its schema.

#### Example Usage

```php
vendor/bin/simple.phpunit
```

