### PR TITLE
Add support for route annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,3 +67,9 @@ script:
   - bin/adminconsole lint:twig templates
   # Lint Yaml files
   - bin/adminconsole lint:yaml config
+  # Debug container
+  - bin/adminconsole debug:container --show-private
+  - bin/websiteconsole debug:container --show-private
+  # Debug routes
+  - bin/adminconsole debug:router
+  - bin/websiteconsole debug:router

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,9 +67,3 @@ script:
   - bin/adminconsole lint:twig templates
   # Lint Yaml files
   - bin/adminconsole lint:yaml config
-  # Debug container
-  - bin/adminconsole debug:container --show-private
-  - bin/websiteconsole debug:container --show-private
-  # Debug routes
-  - bin/adminconsole debug:router
-  - bin/websiteconsole debug:router

--- a/config/routes/sulu_website.yml
+++ b/config/routes/sulu_website.yml
@@ -7,3 +7,7 @@ sulu_search:
 
 sulu_website:
     resource: "@SuluWebsiteBundle/Resources/config/routing_website.yml"
+
+controllers:
+    resource: ../../src/Controller/
+    type: annotation


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Added support for route annotations.

#### Why?

In a default symfony installation this is automatically added by recipe [doctrine/annotations recipe](https://github.com/symfony/recipes/blob/master/doctrine/annotations/1.0/config/routes/annotations.yaml).

#### TODO

 - [x] Folder `src/Controller` need to exist for this (done using .gitignore like symfony)