### PR TITLE
Added autowire and autoconfigure configuration for services

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,6 +4,22 @@ parameters:
 #    parameter_name: value
 
 services:
-#    service_name:
-#        class: AppBundle\Directory\ClassName
-#        arguments: ["@another_service_name", "plain_value", "%parameter_name%"]
+    # default configuration for services in *this* file
+    _defaults:
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+
+    # makes classes in src/ available to be used as services
+    # this creates a service per class whose id is the fully-qualified class name
+    App\:
+        resource: '../src/*'
+        exclude: '../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}'
+
+    # controllers are imported separately to make sure services can be injected
+    # as action arguments even if you don't extend any base controller class
+    App\Controller\:
+        resource: '../src/Controller'
+        tags: ['controller.service_arguments']
+
+    # add more service definitions when explicit configuration is needed
+    # please note that last definitions always *replace* previous ones


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Related PRs | https://github.com/sulu/sulu-minimal/pull/131
| License | MIT

#### What's in this PR?

Added autowire and autoconfigure configuration for services.

#### Why?

This is automatically activated by symfony by [recipe](https://github.com/symfony/recipes/blob/master/symfony/framework-bundle/3.3/config/services.yaml)

#### TODO

 - ~~[ ] Folder `src/Controller` need to exist for this~~ -> #131
