### PR TITLE
Fixed incompatibility with symfony flex for autoruns

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,8 @@
         "symfony/polyfill-php56": "*"
     },
     "scripts": {
-        "auto-scripts": [
+        "sulu-auto-scripts": [
+            "echo 'Use sulu-auto-scripts to avoid problems with symfony/flex: https://github.com/symfony/flex/issues/431'",
             "@php bin/adminconsole cache:clear",
             "@php bin/websiteconsole cache:clear",
             "@php bin/adminconsole assets:install --symlink --relative",
@@ -63,10 +64,10 @@
             "@php bin/adminconsole massive:search:init"
         ],
         "post-install-cmd": [
-            "@auto-scripts"
+            "@sulu-auto-scripts"
         ],
         "post-update-cmd": [
-            "@auto-scripts"
+            "@sulu-auto-scripts"
         ],
         "post-root-package-install": [
             "php -r \"file_put_contents('.env', str_replace('APP_SECRET=', 'APP_SECRET=' . bin2hex(random_bytes(16)), file_get_contents('.env.dist')));\""

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,6 @@
     },
     "scripts": {
         "sulu-auto-scripts": [
-            "# Use sulu-auto-scripts to avoid problems with symfony/flex: https://github.com/symfony/flex/issues/431",
             "@php bin/adminconsole cache:clear",
             "@php bin/websiteconsole cache:clear",
             "@php bin/adminconsole assets:install --symlink --relative",

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     },
     "scripts": {
         "sulu-auto-scripts": [
-            "echo 'Use sulu-auto-scripts to avoid problems with symfony/flex: https://github.com/symfony/flex/issues/431'",
+            "# Use sulu-auto-scripts to avoid problems with symfony/flex: https://github.com/symfony/flex/issues/431",
             "@php bin/adminconsole cache:clear",
             "@php bin/websiteconsole cache:clear",
             "@php bin/adminconsole assets:install --symlink --relative",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Related issues/PRs | https://github.com/symfony/flex/issues/431
| License | MIT

#### What's in this PR?

It renames the auto-scripts section to `sulu-auto-scripts` to avoid problems if somebody have installed symfony/flex.

#### Why?

Symfony flex currently does not work with `@php` commands in [auto-scripts](https://github.com/symfony/flex/blob/v1.1.8/src/Flex.php#L751) and throw an [exception](https://github.com/symfony/flex/blob/v1.1.8/src/ScriptExecutor.php#L89).

This did happen to me as I did work on a symfony pull request and had symfony flex installed globally like they do it in [there ci](https://github.com/symfony/symfony/blob/v4.1.7/.travis.yml#L206).

This pull request avoid problems for people which have symfony flex installed globally.

#### Example Usage

```php
composer global require --no-progress --no-scripts --no-plugins symfony/flex dev-master
composer install
```
