### PR TITLE
Use HttpCache only in website kernel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "symfony/monolog-bundle": "^3.1",
         "symfony/swiftmailer-bundle": "^2.6.4 || ^3.0",
         "symfony/twig-bundle": "^3.4",
-        "toflar/psr6-symfony-http-cache-store": "^1.1",
         "twig/extensions": "^1.0",
         "zendframework/zend-stdlib": "^2.3",
         "zendframework/zendsearch": "^2.0.0rc6"

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "symfony/monolog-bundle": "^3.1",
         "symfony/swiftmailer-bundle": "^2.6.4 || ^3.0",
         "symfony/twig-bundle": "^3.4",
+        "toflar/psr6-symfony-http-cache-store": "^1.1",
         "twig/extensions": "^1.0",
         "zendframework/zend-stdlib": "^2.3",
         "zendframework/zendsearch": "^2.0.0rc6"

--- a/public/index.php
+++ b/public/index.php
@@ -63,7 +63,7 @@ $kernel = new Kernel($env, $debug, $suluContext);
 
 // Comment this line if you want to use the "varnish" http
 // caching strategy. See http://sulu.readthedocs.org/en/latest/cookbook/caching-with-varnish.html
-if ($env !== 'dev') {
+if ($env !== 'dev' && SuluKernel::CONTEXT_WEBSITE === $suluContext) {
     $kernel = $kernel->getHttpCache();
 }
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -17,16 +17,19 @@ use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\HttpCache\HttpCache;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class Kernel extends SuluKernel implements HttpCacheProvider
 {
-    use HttpCacheAware;
+    /**
+     * @var HttpKernelInterface
+     */
+    private $httpCache;
 
     public function __construct(string $environment, bool $debug, string $suluContext = self::CONTEXT_ADMIN)
     {
         parent::__construct($environment, $debug, $suluContext);
-        // HttpCache and HttpCacheProvider is not needed when using varnish
-        $this->setHttpCache(new SuluHttpCache($this));
     }
 
     protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader)
@@ -37,5 +40,14 @@ class Kernel extends SuluKernel implements HttpCacheProvider
         $container->setParameter('container.dumper.inline_class_loader', true);
 
         parent::configureContainer($container, $loader);
+    }
+
+    public function getHttpCache()
+    {
+        if (!$this->httpCache) {
+            $this->httpCache = new SuluHttpCache($this);
+        }
+
+        return $this->httpCache;
     }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -11,13 +11,11 @@ namespace App;
  * with this source code in the file LICENSE.
  */
 
-use FOS\HttpCache\SymfonyCache\HttpCacheAware;
 use FOS\HttpCache\SymfonyCache\HttpCacheProvider;
 use Sulu\Bundle\HttpCacheBundle\Cache\SuluHttpCache;
 use Sulu\Component\HttpKernel\SuluKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\HttpKernel\HttpCache\HttpCache;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class Kernel extends SuluKernel implements HttpCacheProvider


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes --
| Related issues/PRs | --
| License | MIT
| Documentation PR | --

#### What's in this PR?

Use HttpCache only in website kernel.

#### Why?

In the admin kernel it's not necessary.
