### PR TITLE
Add check in preinstall if using yarn and show error message

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "license": "MIT",
     "repository": "https://github.com/sulu/sulu-minimal.git",
     "scripts": {
+        "preinstall": "node vendor/sulu/sulu/preinstall.js",
         "build": "webpack --mode production",
         "watch": "webpack --mode development -w"
     },


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add check in preinstall if using yarn and show error message.

#### Why?

Yarn is currently not supported because of not using symlinks for local dependencies.

#### Example Usage

```php
yarn install
```

Should show a hint to use `npm install` instead

#### TODO

Requires: https://github.com/sulu/sulu/pull/4306