### PR TITLE
Add stage environment based on prod

### DIFF
--- a/.env.stage
+++ b/.env.stage
@@ -1,0 +1,1 @@
+APP_DEBUG=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,15 @@ script:
     fi
   - if [[ $NPM_BUILD = true ]]; then cd ../..; fi
   - composer validate $COMPOSER_VALIDATE_FLAGS
+  # Test Build
   - bin/adminconsole sulu:build dev --no-interaction
+  # Test container build in different environments
+  - bin/adminconsole cache:clear --env stage
+  - bin/websiteconsole cache:clear --env stage
+  - bin/adminconsole cache:clear --env prod
+  - bin/websiteconsole cache:clear --env prod
+  # Lint
+  - bin/adminconsole doctrine:ensure-production-settings --env prod
   - bin/adminconsole doctrine:schema:validate
   - vendor/bin/simple-phpunit
   - bin/adminconsole lint:twig templates

--- a/config/packages/stage/doctrine.yaml
+++ b/config/packages/stage/doctrine.yaml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: '../prod/doctrine.yaml' }

--- a/config/packages/stage/jms_serializer.yaml
+++ b/config/packages/stage/jms_serializer.yaml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: '../prod/jms_serializer.yaml' }

--- a/config/packages/stage/monolog.yaml
+++ b/config/packages/stage/monolog.yaml
@@ -1,0 +1,2 @@
+imports:
+    - { resource: '../prod/monolog.yaml' }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add stage environment based on prod.

#### Why?

Currently if you set your environment to `stage` there is no logging enabled. As it is common to have a stage environment because of the webspace configuration we should provide one to avoid that there is no logging active for the stage env.
