### PR TITLE
Add error pages routes to test environment

### DIFF
--- a/config/routes/test/sulu_website.yaml
+++ b/config/routes/test/sulu_website.yaml
@@ -1,0 +1,3 @@
+_portal_errors:
+    resource: "@SuluWebsiteBundle/Resources/config/routing_error.yml"
+    type: portal


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Add error pages routes to test environment.

#### Why?

Currently its not possible to test the /_error/404 page in the test environment. With this change its finally possible to test the 404 page and validate its response. 
