### PR TITLE
Fix default value for massive search index

### DIFF
--- a/config/packages/massive_search.yaml
+++ b/config/packages/massive_search.yaml
@@ -1,5 +1,5 @@
 parameters:
-    env(MASSIVE_SEARCH_PREFIX): ''
+    env(MASSIVE_SEARCH_PREFIX): 'massive'
 
 massive_search:
     metadata:


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes sulu/sulu#4472
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

The massive search index can not work without a prefix correctly thats why it need to be set. This was accidently included in https://github.com/sulu/sulu-minimal/pull/160

#### Why?

Fix default value for massive search index.
