### PR TITLE
WIP: Fix regenerator runtime for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "postcss-nested": "^2.1.0",
         "postcss-simple-vars": "^4.0.0",
         "raw-loader": "^0.5.1",
+        "regenerator-runtime": "^0.13.2",
         "url-search-params-polyfill": "^2.0.0",
         "webpack": "^4.20.2",
         "webpack-clean-obsolete-chunks": "^0.4.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = (env, argv) => {
     const config = webpackConfig(env, argv);
 
     // For adding custom admin js file uncomment the following line:
-    // config.entry.unshift(path.resolve(__dirname, 'assets/admin/index.js'));
+    // config.entry.push(path.resolve(__dirname, 'assets/admin/index.js'));
 
     return config;
 };


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | https://github.com/sulu/sulu/pull/4425
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add `regenerator-runtime` requirement to build ckeditor like documented in https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/advanced-setup.html#option-building-to-es5-target the regenerator-runtime is required.

#### Why?

That the `regenerator-runtime` is not found is sadly only happens when having custom js e.g.:

```js
/* eslint-disable flowtype/require-valid-file-annotation */
/* eslint-disable import/no-nodejs-modules*/
/* eslint-disable no-undef */
const path = require('path');
const webpackConfig = require('./vendor/sulu/sulu/webpack.config.js');

module.exports = (env, argv) => {
    env = env ? env : {};
    argv = argv ? argv : {};

    env.root_path = __dirname;

    const config = webpackConfig(env, argv);
    config.entry.unshift(path.resolve(__dirname, 'assets/admin/index.js'));

    return config;
};
```

```js
// @flow
import {bundleReady} from 'sulu-admin-bundle/services';
import {fieldRegistry, viewRegistry} from 'sulu-admin-bundle/containers';
import {listToolbarActionRegistry, formToolbarActionRegistry} from 'sulu-admin-bundle/views';
import {listFieldTransformerRegistry} from 'sulu-admin-bundle/containers/List';

// ...

bundleReady();
```

#### Example Usage

The build itself seems to work:

```php
npm run build
```

But when then accessing /admin it crash with regeneratorRuntime not found.