### PR TITLE
WIP: Add a central place where the admin prefix can be changed

### DIFF
--- a/config/packages/fos_rest.yaml
+++ b/config/packages/fos_rest.yaml
@@ -1,3 +1,3 @@
 fos_rest:
     zone:
-        - { path: ^/admin/* }
+        - { path: ^%sulu_admin_prefix%/* }

--- a/config/packages/framework_admin.yaml
+++ b/config/packages/framework_admin.yaml
@@ -1,0 +1,5 @@
+framework:
+    session:
+        cookie_path: "%sulu_admin_prefix%"
+    fragments:
+        path: "%sulu_admin_prefix%/_fragments"

--- a/config/packages/security_admin.yaml
+++ b/config/packages/security_admin.yaml
@@ -11,14 +11,14 @@ security:
             id: sulu_security.user_provider
 
     access_control:
-        - { path: ^/admin/reset, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/admin/security/reset, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/admin/login$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/admin/_wdt, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/admin/translations, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/admin$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/admin/$, roles: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: ^/admin, roles: ROLE_USER }
+        - { path: "^%sulu_admin_prefix%/reset", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%sulu_admin_prefix%/security/reset", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%sulu_admin_prefix%/login$", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%sulu_admin_prefix%/_wdt", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%sulu_admin_prefix%/translations", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%sulu_admin_prefix%$", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%sulu_admin_prefix%/$", roles: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "^%sulu_admin_prefix%", roles: ROLE_USER }
 
     firewalls:
         admin:

--- a/config/routes/dev/web_profiler_admin.yaml
+++ b/config/routes/dev/web_profiler_admin.yaml
@@ -2,10 +2,10 @@ _wdt:
     defaults:
         _requestAnalyzer: false
     resource: "@WebProfilerBundle/Resources/config/routing/wdt.xml"
-    prefix:   /admin/_wdt
+    prefix:   "%sulu_admin_prefix%/_wdt"
 
 _profiler:
     defaults:
         _requestAnalyzer: false
     resource: "@WebProfilerBundle/Resources/config/routing/profiler.xml"
-    prefix:   /admin/_profiler
+    prefix:   "%sulu_admin_prefix%/_profiler"

--- a/config/routes/fos_js_routing_admin.yaml
+++ b/config/routes/fos_js_routing_admin.yaml
@@ -1,3 +1,3 @@
 fos_js_routing:
-    prefix: /admin
+    prefix: "%sulu_admin_prefix%"
     resource: "@FOSJsRoutingBundle/Resources/config/routing/routing.xml"

--- a/config/routes/sulu_admin.yaml
+++ b/config/routes/sulu_admin.yaml
@@ -1,33 +1,33 @@
 sulu_tag_api:
     resource: "@SuluTagBundle/Resources/config/routing_api.yml"
-    prefix:   /admin/api
+    prefix: "%sulu_admin_prefix%/api"
 
 sulu_admin:
     resource: "@SuluAdminBundle/Resources/config/routing.yml"
-    prefix: /admin
+    prefix: "%sulu_admin_prefix%"
 
 sulu_contact_api:
     type: rest
     resource: "@SuluContactBundle/Resources/config/routing_api.yml"
-    prefix: /admin/api
+    prefix: "%sulu_admin_prefix%/api"
 
 sulu_security:
     resource: "@SuluSecurityBundle/Resources/config/routing.xml"
-    prefix: /admin/security
+    prefix: "%sulu_admin_prefix%/security"
 
 sulu_security_api:
     type: rest
     resource: "@SuluSecurityBundle/Resources/config/routing_api.xml"
-    prefix: /admin/api
+    prefix: "%sulu_admin_prefix%/api"
 
 sulu_page_api:
     type: rest
     resource: "@SuluPageBundle/Resources/config/routing_api.yml"
-    prefix: /admin/api
+    prefix: "%sulu_admin_prefix%/api"
 
 sulu_media:
     resource: "@SuluMediaBundle/Resources/config/routing.yml"
-    prefix: /admin/media
+    prefix: "%sulu_admin_prefix%/media"
 
 sulu_media_website:
     resource: "@SuluMediaBundle/Resources/config/routing_website.yml"
@@ -35,51 +35,51 @@ sulu_media_website:
 sulu_media_api:
     type: rest
     resource: "@SuluMediaBundle/Resources/config/routing_api.yml"
-    prefix: /admin/api
+    prefix: "%sulu_admin_prefix%/api"
 
 sulu_category_api:
     type: rest
     resource: "@SuluCategoryBundle/Resources/config/routing_api.yml"
-    prefix: /admin/api
+    prefix: "%sulu_admin_prefix%/api"
 
 sulu_snippet_api:
     resource: "@SuluSnippetBundle/Resources/config/routing_api.yml"
     type: rest
-    prefix: /admin/api
+    prefix: "%sulu_admin_prefix%/api"
 
 sulu_location:
     resource: "@SuluLocationBundle/Resources/config/routing.yml"
-    prefix: /admin/location
+    prefix: "%sulu_admin_prefix%/location"
 
 sulu_website:
     resource: "@SuluWebsiteBundle/Resources/config/routing.yml"
-    prefix: /admin/website
+    prefix: "%sulu_admin_prefix%/website"
 
 sulu_website_api:
     resource: "@SuluWebsiteBundle/Resources/config/routing_api.yml"
     type: rest
-    prefix: /admin/api
+    prefix: "%sulu_admin_prefix%/api"
 
 sulu_core:
     type: rest
     resource: "@SuluCoreBundle/Resources/config/routing_api.xml"
-    prefix: /admin/api
+    prefix: "%sulu_admin_prefix%/api"
 
 sulu_custom_urls_api:
     type: rest
     resource: "@SuluCustomUrlBundle/Resources/config/routing_api.yml"
-    prefix: /admin/api
+    prefix: "%sulu_admin_prefix%/api"
 
 sulu_route_api:
     type: rest
     resource: "@SuluRouteBundle/Resources/config/routing_api.xml"
-    prefix: /admin/api
+    prefix: "%sulu_admin_prefix%/api"
 
 sulu_preview:
     resource: "@SuluPreviewBundle/Resources/config/routing.xml"
-    prefix: /admin/preview
+    prefix: "%sulu_admin_prefix%/preview"
 
 # for preview
 sulu_search:
     resource: "@SuluSearchBundle/Resources/config/routing.yml"
-    prefix: /admin/search
+    prefix: "%sulu_admin_prefix%/search"

--- a/public/index.php
+++ b/public/index.php
@@ -42,7 +42,7 @@ if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false
 
 $suluContext = SuluKernel::CONTEXT_WEBSITE;
 
-if (preg_match('/^\/admin(\/|$)/', $_SERVER['REQUEST_URI'])) {
+if (preg_match('#^' . Kernel::ADMIN_PREFIX . '(/|$)#', $_SERVER['REQUEST_URI'])) {
     $suluContext = SuluKernel::CONTEXT_ADMIN;
 }
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -20,6 +20,8 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class Kernel extends SuluKernel implements HttpCacheProvider
 {
+    const ADMIN_PREFIX = '/my-admin';
+
     /**
      * @var HttpKernelInterface
      */
@@ -47,5 +49,15 @@ class Kernel extends SuluKernel implements HttpCacheProvider
         }
 
         return $this->httpCache;
+    }
+
+    protected function getKernelParameters()
+    {
+        return array_merge(
+            parent::getKernelParameters(),
+            [
+                'sulu_admin_prefix' => self::ADMIN_PREFIX
+            ]
+        );
     }
 }


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | yes
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes-
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add a central place where the admin prefix can be changed.

#### Why?

So the admin url prefix can be changed at a central place.

#### Example Usage

```php
// src/Kernel.php

class Kernel extends SuluKernel implements HttpCacheProvider
{
    const ADMIN_PREFIX = '/my-admin';

    // ...
}
```

#### To Do

- [ ] Create a documentation PR
- [ ] Create PR for sulu/sulu test skeleton
