### PR TITLE
Add massive search test adapter configuration and elastic example

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -2,4 +2,3 @@
 KERNEL_CLASS='App\Kernel'
 APP_SECRET='s$cretf0rt3st'
 DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name_test
-MASSIVE_SEARCH_PREFIX=test

--- a/config/packages/massive_search.yaml
+++ b/config/packages/massive_search.yaml
@@ -4,3 +4,12 @@ parameters:
 massive_search:
     metadata:
         prefix: '%env(resolve:MASSIVE_SEARCH_PREFIX)%'
+
+# By default massive search uses zend lucene index saved in var/indexes folder
+# For multi server setup you can switch to the elasticsearch adapter:
+#
+#    adapter: elastic
+#    adapters:
+#        elastic:
+#            version: 5.6
+#            hosts: ['%env(ELASTICSEARCH_HOST)%']

--- a/config/packages/test/massive_search.yaml
+++ b/config/packages/test/massive_search.yaml
@@ -1,0 +1,2 @@
+massive_search:
+    adapter: test


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add massive search test adapter configuration and elastic example.

#### Why?

So the index is not written when writing tests and have an example configuration for elasticsearch in the bundle so they don't need to search how to configure this.
