### PR TITLE
Add .github folder to ignore export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 /tests/travis.php.ini export-ignore
 appveyor.yml export-ignore
 /.circleci export-ignore
+/.github export-ignore


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Add .github folder to ignore export.

#### Why?

New project don't need the .github files.