### PR TITLE
Update readme badge to show latest pre release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![GitHub license](https://img.shields.io/github/license/sulu/sulu-minimal.svg)](https://github.com/sulu/sulu-minimal/blob/master/LICENSE)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/sulu/sulu-minimal.svg)](https://github.com/sulu/sulu-minimal/releases)
-[![GitHub tag (latest by date)](https://img.shields.io/github/tag-date/sulu/sulu-minimal.svg)](https://github.com/sulu/sulu-minimal/releases)
+[![GitHub tag (latest pre-release)](https://img.shields.io/github/tag-pre/sulu/sulu-minimal.svg)](https://github.com/sulu/sulu-minimal/releases)
 [![Travis](https://travis-ci.org/sulu/sulu-minimal.png?branch=master)](https://travis-ci.org/sulu/sulu-minimal)
 
 Welcome to the Sulu Minimal Edition - the recommended skeleton to start a new [Sulu](https://github.com/sulu/sulu) project.


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Update readme badge to show latest pre release tag.

#### Why?

Should show 2.0.0-RC1
[![GitHub tag (latest pre-release)](https://img.shields.io/github/tag-pre/sulu/sulu-minimal.svg)](https://github.com/sulu/sulu/releases)

 and not 2.0.0-alpha6
[![GitHub tag (latest by date)](https://img.shields.io/github/tag-date/sulu/sulu.svg)](https://github.com/sulu/sulu-minimal/releases)
