### PR TITLE
Set default environment to prod

### DIFF
--- a/.env
+++ b/.env
@@ -14,7 +14,7 @@
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
 ###> symfony/framework-bundle ###
-APP_ENV=dev
+APP_ENV=prod
 APP_SECRET=
 #TRUSTED_PROXIES=127.0.0.1,127.0.0.2
 #TRUSTED_HOSTS=localhost,example.com

--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,7 @@
             "@sulu-auto-scripts"
         ],
         "post-root-package-install": [
+            "php -r \"file_put_contents('.env.local', 'APP_ENV=dev' . PHP_EOL);\"",
             "php -r \"file_put_contents('.env', str_replace('APP_SECRET=', 'APP_SECRET=' . bin2hex(random_bytes(16)), file_get_contents('.env')));\""
         ],
         "post-create-project-cmd": [


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

Set default environment to prod of a project to prod.

#### Why?

To avoid that a application is running accidently in dev mode on a production server @chirimoya suggested to change the default environment to prod. To make it not to hard for developers to start the `composer create-project` will set the .env.local to `dev` environment so I think we have an easy start into the project but still prod as default env when a project is installed on a remote server.
