### PR TITLE
Abandoned sulu/minimal in favor of sulu/skeleton

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "abandoned": "sulu/skeleton",
     "name": "sulu/sulu-minimal",
     "license": "MIT",
     "type": "project",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu/sulu-docs#prnum

#### What's in this PR?

Abandoned sulu/minimal in favor of sulu/skeleton.

#### Why?

The 1.6 with the release of 3.0 is EOL. Upgrade to Skeleton and 2.6 is recommended to get security updates and so on.